### PR TITLE
chore: Lambda URLの再発行用

### DIFF
--- a/infra/backend/lambda.yml
+++ b/infra/backend/lambda.yml
@@ -53,7 +53,7 @@ Resources:
   FunctionUrl:
     Type: AWS::Lambda::Url
     Properties:
-      TargetFunctionArn: !GetAtt BackendFunction.Arn
+      TargetFunctionArn: !Ref BackendFunction
       AuthType: NONE
       Cors:
         AllowOrigins:


### PR DESCRIPTION
This reverts commit ec95b2c22802d1aa4d586165a27be41885985974.